### PR TITLE
Implement energy optimizations with battery calibration

### DIFF
--- a/eTempo/src/BatteryMonitor.h
+++ b/eTempo/src/BatteryMonitor.h
@@ -12,26 +12,44 @@ public:
     virtual float getVoltage() const = 0;
 };
 
+#include "Configuration.h"
+#include "SimpleStorage.h"
 #ifdef ARDUINO
 #include <Arduino.h>
-#include "Configuration.h"
+#endif
 
 class BatteryMonitor : public IBatteryMonitor
 {
 public:
+    BatteryMonitor()
+    {
+        storage.begin(STORAGE_NS);
+        maxVoltage = storage.getFloat(KEY_MAX_VOLTAGE, BatteryConfig::VOLTAGE_FULL);
+    }
+
     int getPercentage() const override
     {
         float voltage = getVoltage();
+
         if (voltage <= BatteryConfig::VOLTAGE_EMPTY)
+        {
+            seenLow = true;
             return 0;
-        if (voltage >= BatteryConfig::VOLTAGE_FULL)
+        }
+
+        if (seenLow && voltage > maxVoltage * 0.95f)
+        {
+            maxVoltage = 0.7f * maxVoltage + 0.3f * voltage;
+            storage.putFloat(KEY_MAX_VOLTAGE, maxVoltage);
+            seenLow = false;
+        }
+
+        if (voltage >= maxVoltage)
             return 100;
 
-        int percentage = static_cast<int>(2836.9625 * pow(voltage, 4) -
-                                          43987.4889 * pow(voltage, 3) +
-                                          255233.8134 * pow(voltage, 2) -
-                                          656689.7123 * voltage +
-                                          632041.7303);
+        float ratio = (voltage - BatteryConfig::VOLTAGE_EMPTY) /
+                      (maxVoltage - BatteryConfig::VOLTAGE_EMPTY);
+        int percentage = static_cast<int>(ratio * 100);
         if (percentage > 100)
             percentage = 100;
         if (percentage < 0)
@@ -39,9 +57,9 @@ public:
         return percentage;
     }
 
-    // Lecture avec moyenne des valeurs
     float getVoltage() const override
     {
+#ifdef ARDUINO
         const int samples = 10;
         float sum = 0;
         for (int i = 0; i < samples; ++i)
@@ -49,6 +67,23 @@ public:
             sum += analogRead(BatteryConfig::PIN_BAT);
         }
         return (sum / samples) / 4096.0f * 7.05f;
-    }
-};
+#else
+        return simulatedVoltage;
 #endif
+    }
+
+#ifndef ARDUINO
+    void setSimulatedVoltage(float v) const { simulatedVoltage = v; }
+#endif
+
+private:
+    static constexpr const char *STORAGE_NS = "battery";
+    static constexpr const char *KEY_MAX_VOLTAGE = "maxV";
+
+    mutable SimpleStorage storage;
+    mutable float maxVoltage = BatteryConfig::VOLTAGE_FULL;
+    mutable bool seenLow = false;
+#ifndef ARDUINO
+    mutable float simulatedVoltage = BatteryConfig::VOLTAGE_FULL;
+#endif
+};

--- a/eTempo/src/Configuration.h
+++ b/eTempo/src/Configuration.h
@@ -16,9 +16,9 @@ struct WifiConfig
 {
     static constexpr const char *NTP_SERVER = "pool.ntp.org";
     static constexpr const char *ACCESS_POINT_NAME = "TempoAP";
-    static const int WIFI_TIMEOUT = 240; // Seconds
+    static const int WIFI_TIMEOUT = 60; // Seconds
     static const int WIFI_CONNECT_RETRIES = 3;
-    static const int WIFI_CONNECT_TIMEOUT = 10; // Seconds per attempt
+    static const int WIFI_CONNECT_TIMEOUT = 5; // Seconds per attempt
 };
 
 struct BatteryConfig

--- a/eTempo/src/Platform.h
+++ b/eTempo/src/Platform.h
@@ -10,20 +10,34 @@
 #include "my_nlohmann/json.hpp"
 using nlohmann::json;
 
+#ifdef ENABLE_DEBUG
 #define DEBUG_INIT() Serial.begin(9600)
 #define DEBUG_PRINT(x) Serial.print(x)
 #define DEBUG_PRINTLN(x) Serial.println(x)
 #define DEBUG_PRINTF(...) Serial.printf(__VA_ARGS__)
+#else
+#define DEBUG_INIT()
+#define DEBUG_PRINT(x)
+#define DEBUG_PRINTLN(x)
+#define DEBUG_PRINTF(...)
+#endif
 
 #else
 
 #include <iostream>
 #include <string>
 
+#ifdef ENABLE_DEBUG
 #define DEBUG_INIT() // Pas besoin d'initialisation spécifique
 #define DEBUG_PRINT(x) std::cout << x
 #define DEBUG_PRINTLN(x) std::cout << x << std::endl
 #define DEBUG_PRINTF(...) printf(__VA_ARGS__)
+#else
+#define DEBUG_INIT()
+#define DEBUG_PRINT(x)
+#define DEBUG_PRINTLN(x)
+#define DEBUG_PRINTF(...)
+#endif
 
 #define F(x) (x)
 using String = std::string;
@@ -32,5 +46,8 @@ using String = std::string;
 
 #include "my_nlohmann/json.hpp"
 using nlohmann::json;
+#ifndef ARDUINO
+#define RTC_DATA_ATTR
+#endif
 
 #endif

--- a/eTempo/src/SimpleStorage.h
+++ b/eTempo/src/SimpleStorage.h
@@ -1,0 +1,52 @@
+#pragma once
+#include "Platform.h"
+
+#ifdef ARDUINO
+#include <Preferences.h>
+class SimpleStorage {
+    Preferences prefs;
+public:
+    bool begin(const char* ns) { return prefs.begin(ns, false); }
+    float getFloat(const char* key, float def) { return prefs.getFloat(key, def); }
+    void putFloat(const char* key, float value) { prefs.putFloat(key, value); }
+};
+#else
+#include <unordered_map>
+#include <fstream>
+#include <sstream>
+
+class SimpleStorage {
+    std::string file;
+    std::unordered_map<std::string, float> data;
+    void load() {
+        if (file.empty()) return;
+        std::ifstream in(file);
+        if (!in) return;
+        std::string line;
+        while (std::getline(in, line)) {
+            std::istringstream iss(line);
+            std::string key; float value;
+            if (iss >> key >> value) data[key] = value;
+        }
+    }
+    void save() const {
+        if (file.empty()) return;
+        std::ofstream out(file);
+        for (const auto& kv : data) out << kv.first << " " << kv.second << "\n";
+    }
+public:
+    bool begin(const char* ns) {
+        file = std::string(ns) + ".store";
+        load();
+        return true;
+    }
+    float getFloat(const char* key, float def) {
+        auto it = data.find(key);
+        return it == data.end() ? def : it->second;
+    }
+    void putFloat(const char* key, float value) {
+        data[key] = value;
+        save();
+    }
+};
+#endif

--- a/eTempo/src/TempoApp.h
+++ b/eTempo/src/TempoApp.h
@@ -60,6 +60,8 @@ private:
 
     String todayColor;
     String tomorrowColor;
+    TempoColor todayColorEnum;
+    TempoColor tomorrowColorEnum;
     String remainingBlueDays;
     String remainingWhiteDays;
     String remainingRedDays;
@@ -90,5 +92,10 @@ private:
     // arret de l'utilisation de la librairie préférences, passage en mémoire RTC
     // Nombre de tentatives pour les retries
     static RTC_DATA_ATTR int retryAttempts;
+    static RTC_DATA_ATTR TempoColor lastTodayColor;
+    static RTC_DATA_ATTR TempoColor lastTomorrowColor;
+    static RTC_DATA_ATTR int lastBlueDays;
+    static RTC_DATA_ATTR int lastWhiteDays;
+    static RTC_DATA_ATTR int lastRedDays;
 };
 #endif

--- a/tests/app/main.cpp
+++ b/tests/app/main.cpp
@@ -7,12 +7,26 @@
 #include "TempoColor.h"
 #include "HttpClientFactory.h"
 #include "TempoColorServiceManager.h"
+#include "BatteryMonitor.h"
+#include <cassert>
 #include <iostream>
 #include <ctime>
 #include "Platform.h"
 
 int main()
 {
+   // Battery calibration basic test
+   {
+      BatteryMonitor monitor;
+      monitor.setSimulatedVoltage(3.4f);
+      monitor.getPercentage(); // mark low
+      monitor.setSimulatedVoltage(4.25f);
+      monitor.getPercentage(); // update max
+      monitor.setSimulatedVoltage(4.25f);
+      int pct = monitor.getPercentage();
+      assert(pct == 100);
+   }
+
    // Define the season and period
    const String season = "2024-2025";
 


### PR DESCRIPTION
## Summary
- add cross‑platform SimpleStorage helper for persistence
- implement adaptive `BatteryMonitor` that stores the max voltage
- shorten WiFi timeouts and make debug logging optional
- drop CPU frequency to 80MHz and disconnect Wi‑Fi before sleep
- skip e‑ink refresh if nothing changed and reuse previous day at 00:05
- add basic battery calibration test

## Testing
- `cmake ..`
- `make -j4`
- `./TempoApp` *(fails: cURL error: Couldn't connect to server)*